### PR TITLE
Remove duplicates while normalizing a scopeset

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -66,6 +66,10 @@ export const normalizeScopeSet = scopeset => {
   while (i < n) {
     let scope = scopeset[i++];
     result.push(scope);
+    // consume duplicates
+    while (i < n && scopeset[i] === scope) {
+      i++;
+    }
     if (scope.endsWith('*')) {
       let prefix = scope.slice(0, -1);
       while (i < n && scopeset[i].startsWith(prefix)) {

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -95,6 +95,21 @@ suite('normalize', () => {
       assert.deepEqual(['ab*', 'b*'],
         utils.normalizeScopeSet(unnormalized));
     });
+
+    test('not normalized, contains duplicates', function() {
+      const unnormalized = ['abc', 'abx*', 'ab*', 'b', 'b*', 'abc*'];
+      unnormalized.sort(utils.scopeCompare);
+      assert.deepEqual(['ab*', 'b*'],
+        utils.normalizeScopeSet(unnormalized));
+    });
+
+    test('not normalized, contains lots of duplicates', function() {
+      const unnormalized = ['abc', 'abx*', 'ab*', 'b', 'b*', 'abc*', 'b*',
+        'b*', 'b*', 'b*'];
+      unnormalized.sort(utils.scopeCompare);
+      assert.deepEqual(['ab*', 'b*'],
+        utils.normalizeScopeSet(unnormalized));
+    });
   });
 
   suite('scopeset merging', function() {


### PR DESCRIPTION
The scopeset ['a*', 'abc'] is equivalent to ['a*'], but then, so is
['a*', 'a*'], so both should be normalized to the smallest set.

(I'm currently using `[...new Set(scopes)]` in tc-auth to work around this)