### PR TITLE
Fix missing export and refactor miss

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -6,7 +6,7 @@ import {patternMatch} from './satisfaction';
  * Validate scope-expression for well-formedness.
  */
 exports.validExpression = function(expr) {
-  assert(expr, 'Scope expression must be objects.');
+  assert(expr, 'Scope expression must exist.');
   assert(typeof expr === 'object' && !Array.isArray(expr), 'Scope expressions must be objects.');
   const keys = Object.keys(expr);
   assert(keys.length === 1, 'Scope expressions must have only one key.');
@@ -37,6 +37,6 @@ exports.satisfiesExpression = function(scopeset, expr) {
   const method = operator === 'AnyOf' ? 'some' : 'every';
   return subexpressions[method](subexpr => typeof subexpr === 'string' ?
     scopeset.some(scope => patternMatch(scope, subexpr)) :
-    exports.satisfiesExpression(patterns, subexpr)
+    exports.satisfiesExpression(scopeset, subexpr)
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
   require('./sets'),
   require('./satisfaction'),
   require('./normalize'),
+  require('./expressions'),
 ].forEach(submodule => {
   for (const key in submodule) {
     if (submodule.hasOwnProperty(key)) {

--- a/test/expression_test.js
+++ b/test/expression_test.js
@@ -73,6 +73,7 @@ suite('scope expression satisfaction:', function() {
     [['abc*'], {AllOf: ['abc', 'ghi']}],
     [[''], {AnyOf: ['abc', 'def']}],
     [['abc:def'], {AnyOf: ['abc', 'def']}],
+    [['xyz', 'abc'], {AllOf: [{AnyOf: [{AllOf: ['foo']}, {AllOf: ['bar']}]}]}],
   ].map(([s, e]) => {
     test(`${JSON.stringify(e)} is _not_ satisfied by ${JSON.stringify(s)}`, scenario(s, e, 'should-fail'));
   });
@@ -85,6 +86,7 @@ suite('scope expression satisfaction:', function() {
     [['abc*'], {AnyOf: ['abc', 'def']}],
     [['abc*'], {AnyOf: ['abc']}],
     [['abc*', 'def*'], {AnyOf: ['abc', 'def']}],
+    [['foo'], {AllOf: [{AnyOf: [{AllOf: ['foo']}, {AllOf: ['bar']}]}]}],
   ].map(([s, e]) => {
     test(`${JSON.stringify(e)} is satisfied by ${JSON.stringify(s)}`, scenario(s, e));
   });


### PR DESCRIPTION
1. Apparently I never exported the new scope expressions stuff so it was unusable from outside the tests.
2. Apparently I forgot to change the last `patterns` to `scopeset` when I refactored that so it was good it was never exported anyway.
3. Apparently I didn't test the case where there were nested expressions for satisfies, so I do that now.

I promise I know how to do programmering. This does shake my trust of that statement though 😭  

We ought to do a good audit of all of this code and the bits that will be in lib-api when I'm done there before we put it in production.