### PR TITLE
Add a function to explain why a scope expression was not satisfied

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,29 @@ scopeUtils.satisfiesExpression(
 )
 ```
 
+If you wish to understand why a certain expression was not satisfied by a scopeset
+you can use the `removeGivenScopes` function. The function returns a scope expression
+where all scopes that exist are missing from the scopeset. Any scopes under an
+`AllOf` key are definitely needed to satisfy the expression and at least
+one of the scopes under an `AnyOf` must be provided to satisfy. If the scope
+expression is satisfied by the scopes provided, this function returns `null`.
+
+```js
+scopeUtils.removeGivenScopes(
+  [
+    'abc',
+  ],
+  {
+    AllOf: [
+      {AnyOf: ['abc']},
+      'def',
+    ]
+  }
+)
+// Returns
+// {AllOf: ['def']}
+```
+
 ### Old Style
 
 These are evaluated with `scopeMatch`.

--- a/test/expression_test.js
+++ b/test/expression_test.js
@@ -92,3 +92,32 @@ suite('scope expression satisfaction:', function() {
   });
 
 });
+
+suite('scope expression failure explanation:', function() {
+
+  function scenario(scopes, expr, explanation) {
+    return () => {
+      assert.deepEqual(explanation, utils.removeGivenScopes(scopes, expr));
+    };
+  }
+
+  [
+    [[], {AllOf: []}, null],
+    [['a'], {AllOf: ['a']}, null],
+    [['a'], {AllOf: ['a', 'b']}, {AllOf: ['b']}],
+    [[], {AnyOf: []}, {AnyOf: []}],
+    [['a'], {AnyOf: ['a', 'b']}, null],
+    [['c'], {AnyOf: ['a', 'b']}, {AnyOf: ['a', 'b']}],
+    [['ghi'], {AnyOf: ['abc', 'def']}, {AnyOf: ['abc', 'def']}],
+    [['ghi'], {AllOf: ['abc', 'def', 'ghi']}, {AllOf: ['abc', 'def']}],
+    [['ghi*', 'fff*'], {AnyOf: ['abc', 'def']}, {AnyOf: ['abc', 'def']}],
+    [
+      ['xyz', 'abc'],
+      {AllOf: [{AnyOf: [{AllOf: ['foo']}, {AllOf: ['bar']}]}]},
+      {AllOf: [{AnyOf: [{AllOf: ['foo']}, {AllOf: ['bar']}]}]},
+    ],
+  ].map(([s, e, expl]) => {
+    test(`Given ${JSON.stringify(s)}, ${JSON.stringify(e)} is explained by ${JSON.stringify(expl)}}`,
+      scenario(s, e, expl));
+  });
+});


### PR DESCRIPTION
This will be required to replace the third part of the current error message from lib-api. This is the part where we say "you are either missing scopes from X or Y or ...

I figure we can maybe do a bit of parsing on the lib-api side to make the output format from this nice or just relay it on as-is.

The basic idea of what this function does is explained in the readme.
  