### PR TITLE
Simplify explained expressions further

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -56,7 +56,7 @@ exports.satisfiesExpression = function(scopeset, expr) {
  * are definitely needed to satisfy the expression and at least
  * one of the scopes under an AnyOf must be provided to satisfy.
  */
-exports.removeGivenScopes = function(scopeset, expr) {
+exports.removeGivenScopes = function(scopeset, expr, topLevel=true) {
   assert(Array.isArray(scopeset), 'Scopeset must be an array.');
 
   if (typeof expr === 'string') {
@@ -67,16 +67,22 @@ exports.removeGivenScopes = function(scopeset, expr) {
   }
 
   if (expr.AllOf) {
-    const AllOf = expr.AllOf.map(e => exports.removeGivenScopes(scopeset, e)).filter(e => e !== null);
+    const AllOf = expr.AllOf.map(e => exports.removeGivenScopes(scopeset, e, false)).filter(e => e !== null);
     if (AllOf.length === 0) {
       return null;
+    }
+    if (AllOf.length === 1 && (!topLevel || typeof AllOf[0] !== 'string')) {
+      return AllOf[0];
     }
     return {AllOf};
   }
 
-  const AnyOf = expr.AnyOf.map(e => exports.removeGivenScopes(scopeset, e));
+  const AnyOf = expr.AnyOf.map(e => exports.removeGivenScopes(scopeset, e, false));
   if (AnyOf.some(e => e === null)) {
     return null;
+  }
+  if (AnyOf.length === 1 && (!topLevel || typeof AnyOf[0] !== 'string')) {
+    return AnyOf[0];
   }
   return {AnyOf};
 };

--- a/test/expression_test.js
+++ b/test/expression_test.js
@@ -117,7 +117,7 @@ suite('scope expression failure explanation:', function() {
     [
       ['xyz', 'abc'],
       {AllOf: [{AnyOf: [{AllOf: ['foo']}, {AllOf: ['bar']}]}]},
-      {AllOf: [{AnyOf: [{AllOf: ['foo']}, {AllOf: ['bar']}]}]},
+      {AnyOf: ['foo', 'bar']},
     ],
   ].map(([s, e, expl]) => {
     test(`Given ${JSON.stringify(s)}, ${JSON.stringify(e)} is explained by ${JSON.stringify(expl)}}`,


### PR DESCRIPTION
This applies the transformation we talked about where singleton lists get merged up. All output should still be valid scope expressions however.

I think this might be nice but can take it or leave it.