### PR TITLE
Avoid doing Object.keys in every satisfiesExpression call

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -30,14 +30,15 @@ exports.validExpression = function(expr) {
  */
 exports.satisfiesExpression = function(scopeset, expr) {
   assert(Array.isArray(scopeset), 'Scopeset must be an array.');
-  assert(exports.validExpression(expr));
-  const operator = Object.keys(expr)[0];
-  const subexpressions = expr[operator];
-  const method = operator === 'AnyOf' ? 'some' : 'every';
-  return subexpressions[method](subexpr => typeof subexpr === 'string' ?
+
+  const subexprSatisfied = subexpr => typeof subexpr === 'string' ?
     scopeset.some(scope => patternMatch(scope, subexpr)) :
-    exports.satisfiesExpression(scopeset, subexpr)
-  );
+    exports.satisfiesExpression(scopeset, subexpr);
+
+  if (expr.AnyOf) {
+    return expr.AnyOf.some(subexprSatisfied);
+  }
+  return expr.AllOf.every(subexprSatisfied);
 };
 
 /**


### PR DESCRIPTION
I didn't realize just how expensive `Object.keys` calls are. This removes them from the `satisfiesExpression` path. They will be hard to remove from `validExpression` so I've just stopped checking if the expression is valid in `satisfiesExpression`. In the 99% case this will have been checked already by lib-api. Does this seem worth it to you?