### PR TITLE
use a slightly more liberal node engine spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha test/*_test.js"
   },
   "engines": {
-    "node": "^8.0.0"
+    "node": ">=8.0.0"
   },
   "main": "./src/index",
   "files": [


### PR DESCRIPTION
Basically, if using node >=9, this change is required.  I've verified that
node v9.11.2 works with this change