### PR TITLE
Bump the minimal node version from 8 to 20

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -23,7 +23,7 @@ tasks:
       deadline: {$fromNow: '1 day'}
       payload:
         maxRunTime: 3600
-        image: "node:10"
+        image: "node:20"
         command:
           - /bin/bash
           - '--login'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha test/*_test.js"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v20.0.0"
   },
   "main": "./src/index",
   "files": [


### PR DESCRIPTION
This raises the minimal node version substantially so we can use modern features/dependencies. I chose 20 because it's the version that stabilized `node:test` in case we want to get rid of mocha. I could have switched to 24 since this is what taskcluster itself is running on but I didn't want to be too strict in case someone else out there uses this.

Closes #93 