### PR TITLE
Switch CI reporting to use checks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,5 @@
 version: 1
+reporting: checks-v1
 policy:
   pullRequests: public
 tasks:


### PR DESCRIPTION
Statuses have been deprecated pretty much for as long as docker worker. So let's try to not use them...